### PR TITLE
explicitly operate on ^out instead of *

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,9 @@ for the up to date details!
   as primary keys instead of full sqlite `text`.
 - Wire's cache is now deleted and recreated if migrations fail.
 - No longer panics on key agent env var not found.
+- Building & Pushing derivation outputs now explicitly operate on the `^out`
+  output instead of incorrectly pushing all outputs (`^*`). This results in a
+  roughly 12% speed increase in benchmarking.
 
 ### Fixed
 

--- a/bench/README.md
+++ b/bench/README.md
@@ -17,7 +17,7 @@ The hive has around 20 nodes and 200 keys each. 80% of the keys are pre-activati
 
 | Command                                         |        Mean [s] | Min [s] | Max [s] |     Relative |
 | :---------------------------------------------- | --------------: | ------: | ------: | -----------: |
-| `wire@HEAD - flake`                             |   5.467 ± 0.061 |   5.406 |   5.561 |  1.15 ± 0.02 |
-| `wire@HEAD & --experimental-nix-client - flake` |   4.773 ± 0.083 |   4.693 |   4.870 |         1.00 |
-| `colmena@pinned - flake`                        | 125.852 ± 0.528 | 125.242 | 126.404 | 26.37 ± 0.47 |
-| `wire@HEAD - hive.nix`                          | 122.832 ± 1.216 | 121.555 | 124.179 | 25.73 ± 0.52 |
+| `wire@HEAD - flake`                             |   4.804 ± 0.081 |   4.710 |   4.886 |  1.04 ± 0.02 |
+| `wire@HEAD & --experimental-nix-client - flake` |   4.636 ± 0.033 |   4.607 |   4.693 |         1.00 |
+| `colmena@pinned - flake`                        | 122.410 ± 1.828 | 120.143 | 125.158 | 26.40 ± 0.44 |
+| `wire@HEAD - hive.nix`                          | 119.883 ± 1.115 | 118.651 | 121.429 | 25.86 ± 0.30 |

--- a/crates/core/src/commands/common.rs
+++ b/crates/core/src/commands/common.rs
@@ -49,7 +49,7 @@ pub async fn push(
             host = target.get_preferred_host()?,
         ),
         match push {
-            Push::Derivation(drv) => format!("{}^* --derivation", drv.to_absolute_path()),
+            Push::Derivation(drv) => format!("{}^out --derivation", drv.to_absolute_path()),
             Push::Path(path) => path.to_absolute_path(),
         },
     ]);

--- a/crates/core/src/hive/steps/build.rs
+++ b/crates/core/src/hive/steps/build.rs
@@ -117,7 +117,7 @@ impl ExecuteStep for Build {
                 "--print-out-paths",
             ]);
             command_string.opt_arg(ctx.modifiers.print_build_logs, "--print-build-logs");
-            command_string.arg(format!("{}^*", top_level.to_absolute_path()));
+            command_string.arg(format!("{}^out", top_level.to_absolute_path()));
 
             let status = run_command_with_env(
                 &CommandArguments::new(command_string, ctx.modifiers)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * `push` and the standard build flow now target the default `out` output instead of all outputs, making output selection more consistent and predictable.
* **Documentation**
  * Updated benchmark results in `bench/README.md` with refreshed mean/min/max/relative timings for the listed commands.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->