### PR TITLE
wait far longer for node to reboot on --reboot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,8 @@ for the up to date details!
   roughly 12% speed increase in benchmarking.
 - Unknown fields in the hive schema are now ignored rather than rejected.
 - Cache database now uses `SqliteJournalMode::Wal` & `SqliteSynchronous::Normal`.
+- Attempting to reconnect to a rebooting node will now wait far longer before
+  giving up.
 
 ### Fixed
 

--- a/crates/core/src/hive/steps/activate.rs
+++ b/crates/core/src/hive/steps/activate.rs
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright 2024-2025 wire Contributors
 
-use std::{fmt::Display, sync::Arc};
+use std::{fmt::Display, sync::Arc, time::Duration};
 
 use tracing::{error, info, instrument, warn};
 
@@ -29,11 +29,16 @@ impl Display for SwitchToConfiguration {
 
 #[allow(clippy::significant_drop_tightening)]
 async fn wait_for_ping(target: &SharedTarget, ctx: &Context) -> Result<(), HiveLibError> {
+    // try to regain connection for 5-ish minutes after a reboot, waiting 30s between
+    // attempts to give the machine time to come back up
+    const PING_INTERVAL: Duration = Duration::from_secs(30);
+    const MAX_ATTEMPTS: u32 = 10;
+
     let target = target.0.read().await;
     let host = target.get_preferred_host()?;
 
-    for num in 0..3 {
-        warn!("Trying to ping {host} (attempt {}/3)", num + 1);
+    for num in 0..MAX_ATTEMPTS {
+        warn!("Trying to ping {host} (attempt {}/{MAX_ATTEMPTS})", num + 1);
 
         let result = target.ping(ctx.modifiers, ctx.should_quit.clone()).await;
 
@@ -41,6 +46,10 @@ async fn wait_for_ping(target: &SharedTarget, ctx: &Context) -> Result<(), HiveL
             info!("Regained connection to {} via {host}", ctx.name);
 
             return Ok(());
+        }
+
+        if num + 1 < MAX_ATTEMPTS {
+            tokio::time::sleep(PING_INTERVAL).await;
         }
     }
 


### PR DESCRIPTION
Closes https://github.com/forallsys/wire/issues/506

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved device reconnection after reboot by retrying ping checks over a longer period instead of stopping after a few quick attempts.
  * Added a pause between retry attempts, which can help avoid premature failure notifications during startup or recovery.
  * Updated warning messages to reflect the new retry behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->