### PR TITLE
Bump `inspect._schema` to 2.

### DIFF
--- a/runtime/evaluate.nix
+++ b/runtime/evaluate.nix
@@ -101,7 +101,7 @@ rec {
 
   topLevels = builtins.mapAttrs (name: _: getTopLevel name) nodes;
   inspect = {
-    _schema = 1;
+    _schema = 2;
 
     nodes = builtins.mapAttrs (_: v: v.config.deployment) nodes;
   };


### PR DESCRIPTION
This is so that users will be forced to bump their input up to `1.5.0`, which is a version that supports reading semver schema versions, which the schema will eventually be updated to report.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the schema version for inspection output to version 2.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->