### PR TITLE
convert parse_partitions to const

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -369,6 +369,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
 
 [[package]]
+name = "const_panic"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e262cdaac42494e3ae34c43969f9cdeb7da178bdb4b66fa6a1ea2edb4c8ae652"
+dependencies = [
+ "typewit",
+]
+
+[[package]]
 name = "convert_case"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1233,23 @@ dependencies = [
  "getrandom 0.3.4",
  "libc",
 ]
+
+[[package]]
+name = "konst"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f660d5f887e3562f9ab6f4a14988795b694099d66b4f5dedc02d197ba9becb1d"
+dependencies = [
+ "const_panic",
+ "konst_proc_macros",
+ "typewit",
+]
+
+[[package]]
+name = "konst_proc_macros"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e037a2e1d8d5fdbd49b16a4ea09d5d6401c1f29eca5ff29d03d3824dba16256a"
 
 [[package]]
 name = "lazy_static"
@@ -2694,6 +2720,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
 
 [[package]]
+name = "typewit"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "214ca0b2191785cbc06209b9ca1861e048e39b5ba33574b3cedd58363d5bb5f6"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3008,6 +3040,7 @@ dependencies = [
  "enum-display-derive",
  "futures",
  "itertools 0.15.0",
+ "konst",
  "miette",
  "owo-colors",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ nix-compat = { git = "https://git.snix.dev/snix/snix.git", features = [
 # ] }
 serde_json = { version = "1.0.145" }
 owo-colors = { version = "4.2.3", features = ["supports-colors"] }
+konst = "0.4.3"
 
 [profile.dev.package.sqlx-macros]
 opt-level = 3

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -33,3 +33,4 @@ signal-hook-tokio = { version = "0.4.0", features = ["futures-v0_3"] }
 signal-hook = "0.4.0"
 clap-markdown = "0.1.5"
 clap_mangen = "0.3.0"
+konst = { workspace = true }

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -8,6 +8,9 @@ use clap_complete::CompletionCandidate;
 use clap_complete::engine::ArgValueCompleter;
 use clap_num::number_range;
 use clap_verbosity_flag::InfoLevel;
+use konst::result::unwrap;
+use konst::string::split_once;
+use konst::{option, result, try_};
 use tokio::runtime::Handle;
 use wire_core::SubCommandModifiers;
 use wire_core::commands::common::get_hive_node_names;
@@ -109,22 +112,27 @@ fn more_than_zero(s: &str) -> Result<usize, String> {
     number_range(s, 1, usize::MAX)
 }
 
-fn parse_partitions(s: &str) -> Result<Partitions, String> {
-    let parts: [&str; 2] = s
-        .split('/')
-        .collect::<Vec<_>>()
-        .try_into()
-        .map_err(|_| "partition must contain exactly one '/'")?;
+const fn parse_partitions(s: &str) -> Result<Partitions, &'static str> {
+    let parts = try_!(option::ok_or!(
+        split_once(s, '/'),
+        "partition must contain exactly one '/'"
+    ));
 
-    let current = parts[0].parse::<usize>().map_err(|e| e.to_string())?;
-    let maximum = parts[1].parse::<usize>().map_err(|e| e.to_string())?;
+    let current = try_!(result::map_err!(
+        usize::from_str_radix(parts.0, 10),
+        |_| "could not parse first half of partition to a usize"
+    ));
+    let maximum = try_!(result::map_err!(
+        usize::from_str_radix(parts.1, 10),
+        |_| "could not parse second half of partition to a usize"
+    ));
 
     if current > maximum {
-        return Err("current is more than total".to_string());
+        return Err("current is more than total");
     }
 
     if current == 0 || maximum == 0 {
-        return Err("partition segments cannot be 0.".to_string());
+        return Err("partition segments cannot be 0.");
     }
 
     Ok(Partitions { current, maximum })
@@ -234,6 +242,12 @@ pub struct Partitions {
     pub maximum: usize = 1,
 }
 
+impl Display for Partitions {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        write!(f, "{}/{}", self.current, self.maximum)
+    }
+}
+
 #[derive(Args)]
 pub struct BuildArgs {
     #[command(flatten)]
@@ -242,7 +256,7 @@ pub struct BuildArgs {
     /// Partition builds into buckets.
     ///
     /// In the format of `current/total`, where 1 <= current <= total.
-    #[arg(short = 'P', default_value="1/1", long, value_parser=parse_partitions)]
+    #[arg(short = 'P', long, value_parser=parse_partitions, default_value_t = const { unwrap!(parse_partitions("1/1")) })]
     pub partition: Partitions,
 }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of build partition values supplied through the command line.
  * Added clearer handling and formatting for partition settings.
  * Preserved the default partition setting of `1/1` while applying the updated validation consistently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->