### PR TITLE
show latest log message in status bar for each node

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   to switch to a newer version of the wire binary that will support switching
   this value to a semver string.
 
+### Fixed
+
+- Status bar overflowing the terminal's width.
+
 ## [0.4.0] - 2025-07-20
 
 In this release garnix has been replaced with our own binary cache as garnix has shutdown.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+- Fix outputting coloured text, disrespecting NO_COLOR, in some case.
+
 ### Changed
 
 - `inspect._schema` was upgraded from `1` to `2`. This was done to force users

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased] - yyyy-mm-dd
 
+### Added
+
+- The last associated nix log is now shown next to the node name, including a
+  possible build name when `--print-build-logs` is passed.
 - Fix outputting coloured text, disrespecting NO_COLOR, in some case.
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -68,7 +68,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -79,7 +79,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -322,7 +322,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -360,6 +360,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fe5f465a4f6fee88fad41b85d990f84c835335e85b5d9e6e63e0d06d28cba7c"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "unicode-width 0.2.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -663,6 +675,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
 name = "enum-display-derive"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -698,7 +716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -862,7 +880,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -1182,7 +1200,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1487,7 +1505,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1550,9 +1568,9 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "owo-colors"
-version = "4.4.0"
+version = "4.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c45bb4a6ae1280ec0803b1ef9d3455eb50f01efbbe1447ab020f1d54fba9d8"
+checksum = "d211803b9b6b570f68772237e415a029d5a50c65d382910b879fb19d3271f94d"
 dependencies = [
  "supports-color 2.1.0",
  "supports-color 3.0.2",
@@ -1912,7 +1930,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1960,7 +1978,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2152,7 +2170,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2363,15 +2381,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "strip-ansi-escapes"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a8f8038e7e7969abb3f1b7c2a811225e9296da208539e0f79c5251d6cac0025"
-dependencies = [
- "vte",
-]
-
-[[package]]
 name = "strsim"
 version = "0.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2438,9 +2447,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.4"
+version = "3.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e6275cddf4610d1775e6d1fe9469b2e77d0f39fd98fb7450901b821e0c53649f"
+checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -2477,7 +2486,7 @@ dependencies = [
  "fastrand",
  "once_cell",
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2487,7 +2496,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2547,7 +2556,7 @@ checksum = "bc04cd3e1236dd4a98afca4569f2deb3f120e5422a4023be2cb683f8486292af"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.4",
+ "syn 3.0.3",
 ]
 
 [[package]]
@@ -2843,15 +2852,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
-name = "vte"
-version = "0.14.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "231fdcd7ef3037e8330d8e17e61011a2c244126acc0a982f4040ac3f9f0bc077"
-dependencies = [
- "memchr",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3079,6 +3079,7 @@ dependencies = [
  "aho-corasick",
  "anyhow",
  "base64 0.23.1",
+ "console",
  "derive_more",
  "enum_dispatch",
  "futures",
@@ -3099,8 +3100,7 @@ dependencies = [
  "serde_json",
  "sha2 0.11.0",
  "sqlx",
- "strip-ansi-escapes",
- "syn 3.0.4",
+ "syn 3.0.3",
  "tempdir",
  "termion",
  "thiserror 2.0.20",

--- a/crates/cli/src/tracing_setup.rs
+++ b/crates/cli/src/tracing_setup.rs
@@ -19,7 +19,7 @@ use tracing_subscriber::{
     registry::LookupSpan,
     util::SubscriberInitExt,
 };
-use wire_core::status::{UI_SENDER, UiMessage};
+use wire_core::status::{BUILD_NAME_CARET, BUILD_NAME_STYLE, UI_SENDER, UiMessage};
 
 /// Forwards log lines to the UI worker over `UI_SENDER`.
 struct NonClobberingWriter;
@@ -211,19 +211,21 @@ where
         if !visitor.build.is_empty() {
             write!(
                 writer,
-                " {}",
+                " {}{}",
                 visitor
                     .build
-                    .if_supports_color(Stream::Stderr, |text| text.dimmed())
+                    .if_supports_color(Stream::Stderr, |text| text.style(BUILD_NAME_STYLE)),
+                BUILD_NAME_CARET
+                    .if_supports_color(Stream::Stderr, |text| text.style(BUILD_NAME_STYLE))
             )?;
         }
 
         if !visitor.msg.is_empty() {
-            write!(writer, " | {}", visitor.msg)?;
+            write!(writer, " {}", visitor.msg)?;
         }
 
         if !visitor.other.is_empty() {
-            write!(writer, " | {}", visitor.other)?;
+            write!(writer, " {}", visitor.other)?;
         }
 
         writeln!(writer)?;

--- a/crates/cli/src/tracing_setup.rs
+++ b/crates/cli/src/tracing_setup.rs
@@ -200,7 +200,12 @@ where
 
         // write the step name
         if let Some(step) = ctx.event_scope().unwrap().from_root().nth(1) {
-            write!(writer, " {}", step.name().italic())?;
+            write!(
+                writer,
+                " {}",
+                step.name()
+                    .if_supports_color(Stream::Stderr, |x| x.italic())
+            )?;
         }
 
         if !visitor.build.is_empty() {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -34,7 +34,6 @@ enum_dispatch = "0.3.13"
 sha2 = { workspace = true }
 base64 = { workspace = true }
 nix-compat = { workspace = true }
-strip-ansi-escapes = "0.2.1"
 aho-corasick = "1.1.4"
 owo-colors = { workspace = true }
 termion = "4.0.6"
@@ -43,6 +42,7 @@ zstd = "0.13.3"
 wire-nix-client = { path = "../nix_client" }
 memchr = "2"
 semver = "1.0.28"
+console = "0.16.4"
 
 [dev-dependencies]
 tempdir = "0.3"

--- a/crates/core/src/cache/mod.rs
+++ b/crates/core/src/cache/mod.rs
@@ -277,7 +277,7 @@ impl InspectionCache {
             node_name: String,
         }
 
-        let mut client = NixClient::open_local(trace_nix_log_message, should_quit, false).await.inspect_err(|err| error!(err = ?err, "failed to open local nix client to verify cached evaluations")).ok()?;
+        let mut client = NixClient::open_local(|log, map, print| trace_nix_log_message(log, map, print, None), should_quit, false).await.inspect_err(|err| error!(err = ?err, "failed to open local nix client to verify cached evaluations")).ok()?;
 
         let store_path_digest = &prefetch.store_path.digest()[..];
         let store_path_name = prefetch.store_path.name();
@@ -480,14 +480,19 @@ where
 
         let mut previous_rowid = 0;
 
-        let mut client =
-            match NixClient::open_local(trace_nix_log_message, should_quit, false).await {
-                Ok(c) => c,
-                Err(err) => {
-                    error!(err = ?err, "failed to open local nix client for gc");
-                    return Ok(());
-                }
-            };
+        let mut client = match NixClient::open_local(
+            |log, map, print| trace_nix_log_message(log, map, print, None),
+            should_quit,
+            false,
+        )
+        .await
+        {
+            Ok(c) => c,
+            Err(err) => {
+                error!(err = ?err, "failed to open local nix client for gc");
+                return Ok(());
+            }
+        };
 
         // delete caches whose flake/output paths no longer exist in the nix store
         loop {

--- a/crates/core/src/commands/common.rs
+++ b/crates/core/src/commands/common.rs
@@ -45,8 +45,9 @@ pub async fn push(
     ]);
 
     let child = run_command_with_env(
-        &CommandArguments::new(command_string, context.modifiers)
-            .mode(crate::commands::ChildOutputMode::Nix),
+        &CommandArguments::new(command_string, context.modifiers).mode(
+            crate::commands::ChildOutputMode::Nix(Some(context.name.clone())),
+        ),
         HashMap::from([(
             "NIX_SSHOPTS".into(),
             target.create_ssh_opts(context.modifiers)?,
@@ -153,7 +154,7 @@ pub async fn evaluate_hive_attribute(
 
     let child = run_command(
         &CommandArguments::new(command_string, modifiers)
-            .mode(crate::commands::ChildOutputMode::Nix),
+            .mode(crate::commands::ChildOutputMode::Nix(None)),
     )
     .await?;
 

--- a/crates/core/src/commands/mod.rs
+++ b/crates/core/src/commands/mod.rs
@@ -4,7 +4,8 @@
 use crate::{
     SafeStorePath,
     commands::pty::{InteractiveChildChip, interactive_command_with_env},
-    hive::node::{BuildNameMap, SharedTarget},
+    hive::node::{BuildNameMap, Name, SharedTarget},
+    status::{UI_SENDER, UiMessage},
 };
 use core::str;
 use std::{
@@ -32,9 +33,9 @@ pub(crate) mod pty;
 static AT_NIX_FINDER: LazyLock<memmem::Finder> =
     LazyLock::new(|| memmem::Finder::new(AT_NIX_PREFIX));
 
-#[derive(Copy, Clone, Debug)]
+#[derive(Clone, Debug)]
 pub(crate) enum ChildOutputMode {
-    Nix,
+    Nix(Option<Name>),
     Generic,
 }
 
@@ -75,7 +76,7 @@ impl<S: AsRef<str>> CommandArguments<S> {
         self
     }
 
-    pub(crate) const fn mode(mut self, mode: ChildOutputMode) -> Self {
+    pub(crate) fn mode(mut self, mode: ChildOutputMode) -> Self {
         self.output_mode = mode;
         self
     }
@@ -156,6 +157,7 @@ pub(crate) fn trace_nix_log_message(
     log_message: LogMessage,
     build_name_map: &BuildNameMap,
     print_build_logs: bool,
+    name: Option<Name>,
 ) -> Option<String> {
     let (msg, level, build_name) = match log_message {
         LogMessage::Start {
@@ -224,6 +226,16 @@ pub(crate) fn trace_nix_log_message(
 
     let msg = strip_ansi_escapes::strip_str(msg);
 
+    if let Some(name) = name
+        && let Some(sender) = UI_SENDER.get()
+    {
+        let _ = sender.send(UiMessage::ContextLogLine {
+            name,
+            log: msg.clone(),
+            build_name: build_name.clone(),
+        });
+    }
+
     let level = log_print(&level, build_name.as_ref(), &msg);
 
     if matches!(level, tracing::Level::ERROR | tracing::Level::WARN) {
@@ -242,20 +254,20 @@ impl ChildOutputMode {
         build_name_map: &BuildNameMap,
         print_build_logs: bool,
     ) -> Option<String> {
-        let slice = match self {
+        let (slice, name) = match self {
             Self::Generic => {
                 let string = String::from_utf8_lossy(line);
                 let stripped = strip_ansi_escapes::strip_str(&string);
                 warn!("{stripped}");
                 return Some(string.to_string());
             }
-            Self::Nix => {
+            Self::Nix(name) => {
                 let position = AT_NIX_FINDER.find(line).map(|starting_position| {
                     &mut line[(starting_position + AT_NIX_PREFIX.len())..]
                 });
 
                 if let Some(json_buf) = position {
-                    json_buf
+                    (json_buf, name)
                 } else {
                     // usually happens when ssh is outputting something
                     warn!("{}", String::from_utf8_lossy(line));
@@ -270,7 +282,7 @@ impl ChildOutputMode {
             return None;
         };
 
-        trace_nix_log_message(log_message, build_name_map, print_build_logs)
+        trace_nix_log_message(log_message, build_name_map, print_build_logs, name)
     }
 }
 

--- a/crates/core/src/commands/mod.rs
+++ b/crates/core/src/commands/mod.rs
@@ -224,14 +224,14 @@ pub(crate) fn trace_nix_log_message(
         return None;
     }
 
-    let msg = strip_ansi_escapes::strip_str(msg);
+    let msg = console::strip_ansi_codes(&msg);
 
     if let Some(name) = name
         && let Some(sender) = UI_SENDER.get()
     {
         let _ = sender.send(UiMessage::ContextLogLine {
             name,
-            log: msg.clone(),
+            log: msg.to_string(),
             build_name: build_name.clone(),
         });
     }
@@ -239,7 +239,7 @@ pub(crate) fn trace_nix_log_message(
     let level = log_print(&level, build_name.as_ref(), &msg);
 
     if matches!(level, tracing::Level::ERROR | tracing::Level::WARN) {
-        return Some(msg);
+        return Some(msg.to_string());
     }
 
     None
@@ -257,7 +257,7 @@ impl ChildOutputMode {
         let (slice, name) = match self {
             Self::Generic => {
                 let string = String::from_utf8_lossy(line);
-                let stripped = strip_ansi_escapes::strip_str(&string);
+                let stripped = console::strip_ansi_codes(&string);
                 warn!("{stripped}");
                 return Some(string.to_string());
             }
@@ -289,7 +289,7 @@ impl ChildOutputMode {
 fn log_print(
     level: &VerbosityLevel,
     build_name: Option<&Arc<String>>,
-    msg: &String,
+    msg: &Cow<'_, str>,
 ) -> tracing::Level {
     let level: tracing::Level = match level {
         VerbosityLevel::Info => tracing::Level::INFO,

--- a/crates/core/src/commands/noninteractive.rs
+++ b/crates/core/src/commands/noninteractive.rs
@@ -51,7 +51,7 @@ pub async fn non_interactive_command_with_env<S: AsRef<str> + Sync>(
         command_string = arguments.command_string.as_ref(),
         extra = match arguments.output_mode {
             ChildOutputMode::Generic => "",
-            ChildOutputMode::Nix => " --log-format internal-json",
+            ChildOutputMode::Nix(..) => " --log-format internal-json",
         }
     );
 
@@ -87,7 +87,7 @@ pub async fn non_interactive_command_with_env<S: AsRef<str> + Sync>(
         .ok_or(HiveLibError::CommandError(CommandError::NoHandle))?;
 
     let mut joinset = JoinSet::new();
-    let output_mode = Arc::new(arguments.output_mode);
+    let output_mode = Arc::new(arguments.output_mode.clone());
 
     joinset.spawn(
         handle_io(
@@ -174,7 +174,11 @@ pub async fn handle_io<R>(
         let mut line = line.into_bytes();
 
         let log = if should_log {
-            Some(output_mode.trace_slice(&mut line, &build_name_map, print_build_logs))
+            Some(output_mode.as_ref().clone().trace_slice(
+                &mut line,
+                &build_name_map,
+                print_build_logs,
+            ))
         } else {
             None
         };

--- a/crates/core/src/commands/pty/mod.rs
+++ b/crates/core/src/commands/pty/mod.rs
@@ -116,7 +116,7 @@ pub async fn interactive_command_with_env<S: AsRef<str> + Sync>(
         "{starting}{command} {flags} {IO_SUBS} && {ending}",
         command = arguments.command_string.as_ref(),
         flags = match arguments.output_mode {
-            ChildOutputMode::Nix => "--log-format internal-json",
+            ChildOutputMode::Nix(..) => "--log-format internal-json",
             ChildOutputMode::Generic => "",
         },
         starting = create_starting_segment(&needles.start),
@@ -162,7 +162,7 @@ pub async fn interactive_command_with_env<S: AsRef<str> + Sync>(
             began_tx,
             reader,
             needles,
-            output_mode: arguments.output_mode,
+            output_mode: arguments.output_mode.clone(),
             stderr_collection: stderr_collection.clone(),
             stdout_collection: stdout_collection.clone(),
             span: Span::current(),

--- a/crates/core/src/commands/pty/output.rs
+++ b/crates/core/src/commands/pty/output.rs
@@ -135,7 +135,7 @@ pub(super) fn handle_pty_stdout(arguments: WatchStdoutArguments) -> Result<(), C
                         &stdout_collection,
                         &mut line,
                         log_stdout,
-                        output_mode,
+                        output_mode.clone(),
                         &build_name_map,
                         print_build_logs,
                     );

--- a/crates/core/src/hive/executor.rs
+++ b/crates/core/src/hive/executor.rs
@@ -183,7 +183,10 @@ pub async fn execute(
         if let Some(tx) = UI_SENDER.get() {
             let _ = tx.send(UiMessage::SetStatus(
                 plan.context.name.clone(),
-                NodeStatus::Running(step.to_string()),
+                NodeStatus::Running {
+                    status: step.to_string(),
+                    last_log: None,
+                },
             ));
         }
 

--- a/crates/core/src/hive/mod.rs
+++ b/crates/core/src/hive/mod.rs
@@ -5,7 +5,7 @@ use itertools::Itertools;
 use nix_compat::flakeref::FlakeRef;
 use nix_compat::nixhash::NixHash;
 use node::{Name, Node};
-use owo_colors::{OwoColorize, Stream};
+use owo_colors::{OwoColorize, Stream, Style};
 use semver::{Version, VersionReq};
 use serde::de::Error;
 use serde::{Deserialize, Deserializer, Serialize};
@@ -168,44 +168,53 @@ impl Display for Hive {
             writeln!(
                 f,
                 "Node {} {}:\n",
-                name.bold(),
+                name.if_supports_color(Stream::Stdout, |x| x.bold()),
                 format!("({})", node.host_platform)
-                    .italic()
-                    .if_supports_color(Stream::Stdout, |x| x.dimmed()),
+                    .if_supports_color(Stream::Stdout, |x| x.style(Style::new().dimmed().italic())),
             )?;
 
             if !node.tags.is_empty() {
-                write!(f, " > {}", "Tags:".bold())?;
+                write!(
+                    f,
+                    " > {}",
+                    "Tags:".if_supports_color(Stream::Stdout, |x| x.bold())
+                )?;
                 writeln!(f, " {:?}", node.tags)?;
             }
 
-            write!(f, " > {}", "Connection:".bold())?;
+            write!(
+                f,
+                " > {}",
+                "Connection:".if_supports_color(Stream::Stdout, |x| x.bold())
+            )?;
             writeln!(f, " {{{}}}", node.target)?;
 
             write!(
                 f,
                 " > {} {}{}",
-                "Build remotely".bold(),
+                "Build remotely".if_supports_color(Stream::Stdout, |x| x.bold()),
                 "`deployment.buildOnTarget`"
-                    .if_supports_color(Stream::Stdout, |x| x.dimmed())
-                    .italic(),
-                ":".bold()
+                    .if_supports_color(Stream::Stdout, |x| x.style(Style::new().dimmed().italic())),
+                ":".if_supports_color(Stream::Stdout, |x| x.bold())
             )?;
             writeln!(f, " {}", node.build_remotely)?;
 
             write!(
                 f,
                 " > {} {}{}",
-                "Local apply allowed".bold(),
+                "Local apply allowed".if_supports_color(Stream::Stdout, |x| x.bold()),
                 "`deployment.allowLocalDeployment`"
-                    .if_supports_color(Stream::Stdout, |x| x.dimmed())
-                    .italic(),
-                ":".bold()
+                    .if_supports_color(Stream::Stdout, |x| x.style(Style::new().dimmed().italic())),
+                ":".if_supports_color(Stream::Stdout, |x| x.bold())
             )?;
             writeln!(f, " {}", node.allow_local_deployment)?;
 
             if !node.keys.is_empty() {
-                write!(f, " > {}", "Keys:".bold())?;
+                write!(
+                    f,
+                    " > {}",
+                    "Keys:".if_supports_color(Stream::Stdout, |x| x.bold())
+                )?;
                 writeln!(f, " {} key(s)", node.keys.len())?;
 
                 for key in &node.keys {
@@ -228,7 +237,11 @@ impl Display for Hive {
             .unique()
             .count();
 
-        write!(f, "{}", "Summary:".bold())?;
+        write!(
+            f,
+            "{}",
+            "Summary:".if_supports_color(Stream::Stdout, |x| x.bold())
+        )?;
         writeln!(
             f,
             " {} total node(s), totalling {} keys ({distinct_keys} distinct).",
@@ -238,7 +251,8 @@ impl Display for Hive {
         writeln!(
             f,
             "{}",
-            "Note: Listed connections are tried from Left to Right".italic(),
+            "Note: Listed connections are tried from Left to Right"
+                .if_supports_color(Stream::Stdout, |x| x.italic()),
         )?;
 
         Ok(())

--- a/crates/core/src/hive/node.rs
+++ b/crates/core/src/hive/node.rs
@@ -108,9 +108,16 @@ impl Target {
         &self,
         modifiers: SubCommandModifiers,
         should_quit: Arc<AtomicBool>,
+        name: &Name,
     ) -> Result<(), HiveLibError> {
         if modifiers.experimental_nix_client {
-            open_remote_client(&self, modifiers, trace_nix_log_message, should_quit).await?;
+            open_remote_client(
+                &self,
+                modifiers,
+                |log, map, print| trace_nix_log_message(log, map, print, Some(name.clone())),
+                should_quit,
+            )
+            .await?;
             return Ok(());
         }
 

--- a/crates/core/src/hive/steps/activate.rs
+++ b/crates/core/src/hive/steps/activate.rs
@@ -45,7 +45,9 @@ async fn wait_for_ping(target: &SharedTarget, ctx: &Context) -> Result<(), HiveL
     for num in 0..MAX_ATTEMPTS {
         warn!("Trying to ping {host} (attempt {}/{MAX_ATTEMPTS})", num + 1);
 
-        let result = target.ping(ctx.modifiers, ctx.should_quit.clone()).await;
+        let result = target
+            .ping(ctx.modifiers, ctx.should_quit.clone(), &ctx.name)
+            .await;
 
         if result.is_ok() {
             info!("Regained connection to {} via {host}", ctx.name);
@@ -78,7 +80,9 @@ impl SwitchToConfiguration {
 
         let child = run_command(
             &CommandArguments::new(command_string, ctx.modifiers)
-                .mode(crate::commands::ChildOutputMode::Nix)
+                .mode(crate::commands::ChildOutputMode::Nix(Some(
+                    ctx.name.clone(),
+                )))
                 .execute_on_remote(self.target.clone())
                 .privileged(&self.privilege_escalation_command),
         )

--- a/crates/core/src/hive/steps/build.rs
+++ b/crates/core/src/hive/steps/build.rs
@@ -74,7 +74,9 @@ impl ExecuteStep for Build {
                         open_remote_client(
                             &target,
                             ctx.modifiers,
-                            trace_nix_log_message,
+                            |log, map, print| {
+                                trace_nix_log_message(log, map, print, Some(ctx.name.clone()))
+                            },
                             ctx.should_quit.clone(),
                         )
                         .await?
@@ -83,7 +85,9 @@ impl ExecuteStep for Build {
                 } else {
                     Either::Right(
                         NixClient::open_local(
-                            trace_nix_log_message,
+                            |log, map, print| {
+                                trace_nix_log_message(log, map, print, Some(ctx.name.clone()))
+                            },
                             ctx.should_quit.clone(),
                             ctx.modifiers.print_build_logs,
                         )
@@ -195,7 +199,9 @@ impl ExecuteStep for Build {
                             }
                             NixCommandBuildMetadata::Locally { .. } => None,
                         })
-                        .mode(crate::commands::ChildOutputMode::Nix)
+                        .mode(crate::commands::ChildOutputMode::Nix(Some(
+                            ctx.name.clone(),
+                        )))
                         .log_stdout(),
                     std::collections::HashMap::new(),
                 )

--- a/crates/core/src/hive/steps/ping.rs
+++ b/crates/core/src/hive/steps/ping.rs
@@ -35,7 +35,7 @@ impl ExecuteStep for Ping {
             );
 
             if target
-                .ping(ctx.modifiers, ctx.should_quit.clone())
+                .ping(ctx.modifiers, ctx.should_quit.clone(), &ctx.name)
                 .await
                 .is_ok()
             {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -167,7 +167,7 @@ pub async fn push_with_daemon(
     substitute_on_destination: bool,
 ) -> Result<(), HiveLibError> {
     let mut local_daemon = NixClient::open_local(
-        trace_nix_log_message,
+        |log, map, print| trace_nix_log_message(log, map, print, Some(context.name.clone())),
         context.should_quit.clone(),
         context.modifiers.print_build_logs,
     )
@@ -179,7 +179,7 @@ pub async fn push_with_daemon(
     let (mut remote_daemon, host) = open_remote_client(
         &target,
         context.modifiers,
-        trace_nix_log_message,
+        |log, map, print| trace_nix_log_message(log, map, print, Some(context.name.clone())),
         context.should_quit.clone(),
     )
     .await?;

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -1,11 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Copyright 2024-2025 wire Contributors
 
-use owo_colors::OwoColorize;
+use owo_colors::{OwoColorize, Stream, Style};
 use std::{
     collections::VecDeque,
     fmt::Write,
-    sync::OnceLock,
+    sync::{Arc, OnceLock},
     time::{Duration, Instant},
 };
 use termion::{clear, cursor, terminal_size};
@@ -18,12 +18,19 @@ use crate::hive::node::Name;
 
 use std::collections::HashMap;
 
+pub const BUILD_NAME_STYLE: Style = Style::new().dimmed();
+pub const BUILD_NAME_CARET: &'static str = ">";
+
 // Statuses are ordered deliberately such that failed nodes are at the top of
 // the list and Succeeded nodes are at the bottom / never shown.
 #[derive(Default, PartialEq, PartialOrd, Ord, Eq)]
 pub enum NodeStatus {
     Failed,
-    Running(String),
+    Running {
+        status: String,
+        /// optional previous log with associated build name
+        last_log: Option<(String, Option<Arc<String>>)>,
+    },
     #[default]
     Pending,
     Succeeded,
@@ -43,8 +50,15 @@ pub enum UiMessage {
     Release,
     /// Clear the status line, mostly for when the program is about to end
     Clear,
-    /// Writes above the status line
+    /// Writes above the status line, optionally ties it to a specific node
     LogLine(Vec<u8>),
+    /// A log line with associated context, including name and possible build
+    /// name
+    ContextLogLine {
+        name: Name,
+        build_name: Option<Arc<String>>,
+        log: String,
+    },
 }
 
 pub struct Status {
@@ -82,7 +96,7 @@ impl Status {
             (0, 0, 0),
             |(mut finished, mut running, mut failed), status| {
                 let did_fail = matches!(status, NodeStatus::Failed);
-                let is_running = matches!(status, NodeStatus::Running(..));
+                let is_running = matches!(status, NodeStatus::Running { .. });
                 let did_succeeded = matches!(status, NodeStatus::Succeeded | NodeStatus::Failed);
 
                 if did_fail {
@@ -190,6 +204,34 @@ impl Status {
                         )
                         .to_string()
                     }
+                    NodeStatus::Running {
+                        status,
+                        last_log: Some((last_log, None)),
+                    } => {
+                        format!(
+                            "{} {}",
+                            status.if_supports_color(Stream::Stderr, |x| x
+                                .style(Style::new().blue().on_default_color())),
+                            last_log
+                        )
+                        .to_string()
+                    }
+                    NodeStatus::Running {
+                        status,
+                        last_log: Some((last_log, Some(build_name))),
+                    } => {
+                        format!(
+                            "{} {}{} {}",
+                            status.if_supports_color(Stream::Stderr, |x| x
+                                .style(Style::new().blue().on_default_color())),
+                            build_name
+                                .if_supports_color(Stream::Stderr, |x| x.style(BUILD_NAME_STYLE)),
+                            BUILD_NAME_CARET
+                                .if_supports_color(Stream::Stderr, |x| x.style(BUILD_NAME_STYLE)),
+                            last_log
+                        )
+                        .to_string()
+                    }
                     NodeStatus::Succeeded => unreachable!("filtered above"),
                     NodeStatus::Failed => "Failed"
                         .if_supports_color(Stream::Stderr, |x| x.red())
@@ -290,6 +332,13 @@ pub async fn status_tick_worker(mut rx: UnboundedReceiver<UiMessage>, show_progr
                     },
                     UiMessage::Clear => {
                         status.clear(&mut stderr);
+                    },
+                    UiMessage::ContextLogLine { name, log, build_name } => {
+                        if let Some(node_status) = status.statuses.get_mut(&name) && let NodeStatus::Running { last_log, .. } = node_status {
+                            // ensure only a single line is kept or the status
+                            // bar might accidentally spread into multiple lines
+                            *last_log = log.lines().next().map(|log| (log.to_string(), build_name));
+                        }
                     },
                     UiMessage::LogLine(line) => {
                         if taken_over {

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -19,11 +19,12 @@ use crate::hive::node::Name;
 use std::collections::HashMap;
 
 pub const BUILD_NAME_STYLE: Style = Style::new().dimmed();
-pub const BUILD_NAME_CARET: &'static str = ">";
+pub const BUILD_NAME_CARET: &str = ">";
 
 // Statuses are ordered deliberately such that failed nodes are at the top of
 // the list and Succeeded nodes are at the bottom / never shown.
-#[derive(Default, PartialEq, PartialOrd, Ord, Eq)]
+#[derive(Default, PartialEq, Eq)]
+#[repr(u16)]
 pub enum NodeStatus {
     Failed,
     Running {
@@ -34,6 +35,12 @@ pub enum NodeStatus {
     #[default]
     Pending,
     Succeeded,
+}
+
+struct NumStatusCount {
+    finished: i32,
+    running: i32,
+    failed: i32,
 }
 
 pub enum UiMessage {
@@ -72,6 +79,73 @@ pub static UI_SENDER: OnceLock<mpsc::UnboundedSender<UiMessage>> = OnceLock::new
 const MAX_NODE_NAME_LENGTH: usize = 20;
 const FALLBACK_TERMINAL_ROWS: usize = 24;
 
+impl NodeStatus {
+    // manually implemented Ord for NodeStatus, since we want to ignore the
+    // enum fields in order, as they can rapidly change
+    fn discriminant(&self) -> u16 {
+        match self {
+            Self::Failed => 0,
+            Self::Running { .. } => 1,
+            Self::Pending => 2,
+            Self::Succeeded => 3,
+        }
+    }
+
+    fn render(&self) -> String {
+        match self {
+            Self::Pending => "Waiting"
+                .if_supports_color(Stream::Stderr, |x| x.dimmed())
+                .to_string(),
+            Self::Running {
+                status,
+                last_log: None,
+            } => format!(
+                "{}",
+                status.if_supports_color(Stream::Stderr, |x| x
+                    .style(Style::new().blue().on_default_color()))
+            ),
+            Self::Running {
+                status,
+                last_log: Some((last_log, None)),
+            } => format!(
+                "{} {}",
+                status.if_supports_color(Stream::Stderr, |x| x
+                    .style(Style::new().blue().on_default_color())),
+                last_log
+            ),
+            Self::Running {
+                status,
+                last_log: Some((last_log, Some(build_name))),
+            } => format!(
+                "{} {}{} {}",
+                status.if_supports_color(Stream::Stderr, |x| x
+                    .style(Style::new().blue().on_default_color())),
+                build_name.if_supports_color(Stream::Stderr, |x| x.style(BUILD_NAME_STYLE)),
+                BUILD_NAME_CARET.if_supports_color(Stream::Stderr, |x| x.style(BUILD_NAME_STYLE)),
+                last_log
+            ),
+            Self::Succeeded => "Succeeded"
+                .if_supports_color(Stream::Stderr, |x| x.green())
+                .to_string(),
+            Self::Failed => "Failed"
+                .if_supports_color(Stream::Stderr, |x| x.red())
+                .to_string(),
+        }
+    }
+}
+
+impl PartialOrd for NodeStatus {
+    fn partial_cmp(&self, other: &Self) -> Option<std::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Ord for NodeStatus {
+    fn cmp(&self, other: &Self) -> std::cmp::Ordering {
+        self.discriminant().cmp(&other.discriminant())
+    }
+}
+
 impl Status {
     fn new() -> Self {
         Self {
@@ -86,50 +160,59 @@ impl Status {
         self.show_progress = show_progress;
     }
 
+    fn count_statuses(&self) -> NumStatusCount {
+        self.statuses.values().fold(
+            NumStatusCount {
+                finished: 0,
+                running: 0,
+                failed: 0,
+            },
+            |mut count, status| {
+                let did_fail = matches!(status, NodeStatus::Failed);
+                let is_running = matches!(status, NodeStatus::Running { .. });
+                let did_succeeded = matches!(status, NodeStatus::Succeeded | NodeStatus::Failed);
+
+                if did_fail {
+                    count.failed += 1;
+                }
+
+                if is_running {
+                    count.running += 1;
+                }
+
+                if did_succeeded || did_fail {
+                    count.finished += 1;
+                }
+
+                count
+            },
+        )
+    }
+
     #[must_use]
     pub fn get_msg(&self) -> String {
         if self.statuses.is_empty() {
             return String::new();
         }
 
-        let (num_finished, num_running, num_failed) = self.statuses.values().fold(
-            (0, 0, 0),
-            |(mut finished, mut running, mut failed), status| {
-                let did_fail = matches!(status, NodeStatus::Failed);
-                let is_running = matches!(status, NodeStatus::Running { .. });
-                let did_succeeded = matches!(status, NodeStatus::Succeeded | NodeStatus::Failed);
+        let count = self.count_statuses();
+        let mut msg = format!("[{} / {}", count.finished, self.statuses.len());
 
-                if did_fail {
-                    failed += 1;
-                }
-
-                if is_running {
-                    running += 1;
-                }
-
-                if did_succeeded || did_fail {
-                    finished += 1;
-                }
-
-                (finished, running, failed)
-            },
-        );
-
-        let mut msg = format!("[{} / {}", num_finished, self.statuses.len());
-
-        let failed = if num_failed >= 1 {
+        let failed = if count.failed >= 1 {
             Some(format!(
                 "{} Failed",
-                num_failed.if_supports_color(Stream::Stderr, |x| x.red())
+                count.failed.if_supports_color(Stream::Stderr, |x| x.red())
             ))
         } else {
             None
         };
 
-        let running = if num_running >= 1 {
+        let running = if count.running >= 1 {
             Some(format!(
                 "{} Deploying",
-                num_running.if_supports_color(Stream::Stderr, |x| x.blue())
+                count
+                    .running
+                    .if_supports_color(Stream::Stderr, |x| x.blue())
             ))
         } else {
             None
@@ -185,60 +268,13 @@ impl Status {
                 break;
             }
 
-            let line = format!(
+            let _ = write!(
+                &mut msg,
                 "\n  {}{} {}",
                 truncated.if_supports_color(Stream::Stderr, |x| x.bold()),
                 " ".repeat(max_name_len.saturating_sub(truncated.len())),
-                match status {
-                    NodeStatus::Pending => "Waiting"
-                        .if_supports_color(Stream::Stderr, |x| x.dimmed())
-                        .to_string(),
-                    NodeStatus::Running {
-                        status,
-                        last_log: None,
-                    } => {
-                        format!(
-                            "{}",
-                            status.if_supports_color(Stream::Stderr, |x| x
-                                .style(Style::new().blue().on_default_color()))
-                        )
-                        .to_string()
-                    }
-                    NodeStatus::Running {
-                        status,
-                        last_log: Some((last_log, None)),
-                    } => {
-                        format!(
-                            "{} {}",
-                            status.if_supports_color(Stream::Stderr, |x| x
-                                .style(Style::new().blue().on_default_color())),
-                            last_log
-                        )
-                        .to_string()
-                    }
-                    NodeStatus::Running {
-                        status,
-                        last_log: Some((last_log, Some(build_name))),
-                    } => {
-                        format!(
-                            "{} {}{} {}",
-                            status.if_supports_color(Stream::Stderr, |x| x
-                                .style(Style::new().blue().on_default_color())),
-                            build_name
-                                .if_supports_color(Stream::Stderr, |x| x.style(BUILD_NAME_STYLE)),
-                            BUILD_NAME_CARET
-                                .if_supports_color(Stream::Stderr, |x| x.style(BUILD_NAME_STYLE)),
-                            last_log
-                        )
-                        .to_string()
-                    }
-                    NodeStatus::Succeeded => unreachable!("filtered above"),
-                    NodeStatus::Failed => "Failed"
-                        .if_supports_color(Stream::Stderr, |x| x.red())
-                        .to_string(),
-                }
+                status.render()
             );
-            let _ = write!(&mut msg, "{line}");
             shown += 1;
         }
 

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -104,13 +104,19 @@ impl Status {
         let mut msg = format!("[{} / {}", num_finished, self.statuses.len());
 
         let failed = if num_failed >= 1 {
-            Some(format!("{} Failed", num_failed.red()))
+            Some(format!(
+                "{} Failed",
+                num_failed.if_supports_color(Stream::Stderr, |x| x.red())
+            ))
         } else {
             None
         };
 
         let running = if num_running >= 1 {
-            Some(format!("{} Deploying", num_running.blue()))
+            Some(format!(
+                "{} Deploying",
+                num_running.if_supports_color(Stream::Stderr, |x| x.blue())
+            ))
         } else {
             None
         };
@@ -167,17 +173,27 @@ impl Status {
 
             let line = format!(
                 "\n  {}{} {}",
-                truncated.bold(),
+                truncated.if_supports_color(Stream::Stderr, |x| x.bold()),
                 " ".repeat(max_name_len.saturating_sub(truncated.len())),
                 match status {
-                    NodeStatus::Pending => "Waiting".dimmed().to_string(),
-                    NodeStatus::Running(task) => {
-                        format!("Running {}", task.blue())
-                            .on_default_color()
-                            .to_string()
+                    NodeStatus::Pending => "Waiting"
+                        .if_supports_color(Stream::Stderr, |x| x.dimmed())
+                        .to_string(),
+                    NodeStatus::Running {
+                        status,
+                        last_log: None,
+                    } => {
+                        format!(
+                            "{}",
+                            status.if_supports_color(Stream::Stderr, |x| x
+                                .style(Style::new().blue().on_default_color()))
+                        )
+                        .to_string()
                     }
                     NodeStatus::Succeeded => unreachable!("filtered above"),
-                    NodeStatus::Failed => "Failed".red().to_string(),
+                    NodeStatus::Failed => "Failed"
+                        .if_supports_color(Stream::Stderr, |x| x.red())
+                        .to_string(),
                 }
             );
             let _ = write!(&mut msg, "{line}");

--- a/crates/core/src/status.rs
+++ b/crates/core/src/status.rs
@@ -78,6 +78,7 @@ pub struct Status {
 pub static UI_SENDER: OnceLock<mpsc::UnboundedSender<UiMessage>> = OnceLock::new();
 const MAX_NODE_NAME_LENGTH: usize = 20;
 const FALLBACK_TERMINAL_ROWS: usize = 24;
+const FALLBACK_TERMINAL_COLS: usize = 100;
 
 impl NodeStatus {
     // manually implemented Ord for NodeStatus, since we want to ignore the
@@ -189,13 +190,9 @@ impl Status {
         )
     }
 
-    #[must_use]
-    pub fn get_msg(&self) -> String {
-        if self.statuses.is_empty() {
-            return String::new();
-        }
-
+    fn get_header(&self) -> String {
         let count = self.count_statuses();
+
         let mut msg = format!("[{} / {}", count.finished, self.statuses.len());
 
         let failed = if count.failed >= 1 {
@@ -228,6 +225,19 @@ impl Status {
 
         let _ = write!(&mut msg, " {}s", self.began.elapsed().as_secs());
 
+        msg
+    }
+
+    #[must_use]
+    pub fn get_msg(&self) -> String {
+        if self.statuses.is_empty() {
+            return String::new();
+        }
+
+        let rows = terminal_size().map_or(FALLBACK_TERMINAL_ROWS, |(_, r)| r as usize);
+        let cols = terminal_size().map_or(FALLBACK_TERMINAL_COLS, |(c, _)| c as usize);
+        let mut msg = console::truncate_str(&self.get_header(), cols, "...").to_string();
+
         let mut entries: Vec<(String, &NodeStatus)> = self
             .statuses
             .iter()
@@ -259,7 +269,6 @@ impl Status {
 
         // cap the displayed node lines to half the terminal height.
         // this keeps the status bar from overflowing.
-        let rows = terminal_size().map_or(FALLBACK_TERMINAL_ROWS, |(_, r)| r as usize);
         let cap = rows.saturating_sub(1).max(1) / 2;
 
         let mut shown = 0;
@@ -268,13 +277,13 @@ impl Status {
                 break;
             }
 
-            let _ = write!(
-                &mut msg,
+            let line = format!(
                 "\n  {}{} {}",
                 truncated.if_supports_color(Stream::Stderr, |x| x.bold()),
                 " ".repeat(max_name_len.saturating_sub(truncated.len())),
                 status.render()
             );
+            let _ = write!(&mut msg, "{}", console::truncate_str(&line, cols, "..."));
             shown += 1;
         }
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Node status now displays the most recent Nix log line alongside the node name.
  - Build names appear with associated logs when `--print-build-logs` is enabled.
  - Nix command output now links logs to the relevant build context.

- **Bug Fixes**
  - Fixed status bar overflow on narrow terminals.
  - Improved handling of `NO_COLOR` for color-free output.

- **Style**
  - Improved event formatting and consistent build-name styling.

- **Documentation**
  - Updated the unreleased changelog with these changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->