### PR TITLE
add --option argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - The last associated nix log is now shown next to the node name, including a
   possible build name when `--print-build-logs` is passed.
 - Fix outputting coloured text, disrespecting NO_COLOR, in some case.
+- `--option` argument for `wire apply` and `wire build`.
 
 ### Changed
 

--- a/crates/cli/src/apply.rs
+++ b/crates/cli/src/apply.rs
@@ -113,10 +113,10 @@ where
 
 fn select_names(
     args: &CommonVerbArgs,
-    mut modifiers: SubCommandModifiers,
+    modifiers: &mut SubCommandModifiers,
     hive: &Hive,
 ) -> Result<Vec<Name>> {
-    let (tags, names) = resolve_targets(&args.on, &mut modifiers)?;
+    let (tags, names) = resolve_targets(&args.on, modifiers)?;
 
     let selected_names: Vec<_> = hive
         .nodes
@@ -145,6 +145,18 @@ fn statusbar_clear_names() {
     }
 }
 
+/// parition a vector of names and results into a list of successful names and errors
+fn partition_results(
+    result: Vec<(Name, Result<(), HiveLibError>)>,
+) -> (Vec<Name>, Vec<(Name, HiveLibError)>) {
+    result
+        .into_iter()
+        .partition_map(|(name, result)| match result {
+            Ok(..) => Either::Left(name),
+            Err(err) => Either::Right((name, err)),
+        })
+}
+
 #[allow(clippy::missing_errors_doc)]
 pub async fn run_goal<F>(hive: &mut Hive, make_goal: F, arguments: RunGoalArguments) -> Result<()>
 where
@@ -155,12 +167,13 @@ where
         location,
         args,
         partition,
-        modifiers,
+        mut modifiers,
         cache,
     } = arguments;
 
     let location = Arc::new(location);
-    let selected_names = select_names(&args, modifiers, hive)?;
+    let selected_names = select_names(&args, &mut modifiers, hive)?;
+    let modifiers = Arc::new(modifiers);
     let num_selected = selected_names.len();
     let partitioned_names = partition_slice(&selected_names, &partition).to_vec();
 
@@ -232,19 +245,13 @@ where
     }
 
     let futures = futures::stream::iter(set).buffer_unordered(args.parallel);
-    let result = futures.collect::<Vec<_>>().await;
+    let results = futures.collect::<Vec<_>>().await;
 
     for task in evaluation_cache_tasks {
         let _ = task.await;
     }
 
-    let (successful, errors): (Vec<_>, Vec<_>) =
-        result
-            .into_iter()
-            .partition_map(|(name, result)| match result {
-                Ok(..) => Either::Left(name),
-                Err(err) => Either::Right((name, err)),
-            });
+    let (successful, errors) = partition_results(results);
 
     if !successful.is_empty() {
         info!(

--- a/crates/cli/src/cli.rs
+++ b/crates/cli/src/cli.rs
@@ -202,6 +202,13 @@ pub struct CommonVerbArgs {
         help_heading = NIX_OPTIONS_HELP_HEADING
     )]
     pub print_build_logs: bool,
+
+    /// Set nix option name to value, overriding nix.conf.
+    ///
+    /// This option does not apply to the experimental nix client.
+    /// Passing nix options disables wire's evaluation cache.
+    #[arg(long, value_names = ["NAME", "VALUE"], num_args = 2, action = ArgAction::Append)]
+    pub option: Vec<String>,
 }
 
 #[allow(clippy::struct_excessive_bools)]
@@ -368,14 +375,30 @@ impl ToSubCommandModifiers for Cli {
                 Commands::Apply(args) => args.ssh_verbose.into(),
                 _ => 0,
             },
+            options: match &self.command {
+                Commands::Apply(args) => chunk_nix_options(&args.common.option),
+                Commands::Build(args) => chunk_nix_options(&args.common.option),
+                Commands::Inspect { .. } => Arc::new(Vec::new()),
+            },
         }
     }
+}
+
+fn chunk_nix_options(options: &[String]) -> Arc<Vec<(String, String)>> {
+    Arc::new(
+        options
+            .as_chunks::<2>()
+            .0
+            .iter()
+            .map(|x| (x[0].clone(), x[1].clone()))
+            .collect::<Vec<(_, _)>>(),
+    )
 }
 
 fn node_names_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
     tokio::task::block_in_place(|| {
         let handle = Handle::current();
-        let modifiers = SubCommandModifiers::default();
+        let modifiers = Arc::new(SubCommandModifiers::default());
         let mut completions = vec![];
 
         if current.is_empty() || current == "-" {
@@ -390,7 +413,7 @@ fn node_names_completer(current: &std::ffi::OsStr) -> Vec<CompletionCandidate> {
 
         let Ok(hive_location) = handle.block_on(get_hive_location(
             current_dir.display().to_string(),
-            modifiers,
+            modifiers.clone(),
         )) else {
             return completions;
         };

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -84,7 +84,7 @@ async fn main() -> Result<()> {
     let should_shutdown = Arc::new(AtomicBool::new(false));
     let signals_task = tokio::spawn(handle_signals(signals, should_shutdown.clone()));
 
-    let location = get_hive_location(args.path, modifiers).await?;
+    let location = get_hive_location(args.path, modifiers.clone().into()).await?;
     let cache = Arc::new(InspectionCache::new().await);
 
     dispatch_command(
@@ -135,7 +135,8 @@ async fn dispatch_command(
 ) -> Result<()> {
     match args {
         cli::Commands::Apply(apply_args) => {
-            let mut hive = Hive::new_from_path(&location, cache.clone(), modifiers).await?;
+            let mut hive =
+                Hive::new_from_path(&location, cache.clone(), modifiers.clone().into()).await?;
             let goal = apply_args.goal.clone().try_into().unwrap();
 
             // Respect user's --always-build-local arg
@@ -162,14 +163,15 @@ async fn dispatch_command(
                     location,
                     args: apply_args.common,
                     partition: Partitions::default(),
-                    modifiers,
+                    modifiers: modifiers.clone(),
                     cache: cache.clone(),
                 },
             )
             .await?;
         }
         cli::Commands::Build(build_args) => {
-            let mut hive = Hive::new_from_path(&location, cache.clone(), modifiers).await?;
+            let mut hive =
+                Hive::new_from_path(&location, cache.clone(), modifiers.clone().into()).await?;
 
             apply::run_goal(
                 &mut hive,
@@ -188,7 +190,8 @@ async fn dispatch_command(
         cli::Commands::Inspect { json, selection } => println!("{}", {
             match selection {
                 cli::Inspection::Full => {
-                    let hive = Hive::new_from_path(&location, cache.clone(), modifiers).await?;
+                    let hive =
+                        Hive::new_from_path(&location, cache.clone(), modifiers.into()).await?;
                     if json {
                         serde_json::to_string(&hive).into_diagnostic()?
                     } else {
@@ -197,7 +200,7 @@ async fn dispatch_command(
                     }
                 }
                 cli::Inspection::Names => {
-                    let names = get_hive_node_names(&location, modifiers).await?;
+                    let names = get_hive_node_names(&location, modifiers.into()).await?;
 
                     if json {
                         serde_json::to_string(&names).into_diagnostic()?

--- a/crates/core/src/commands/builder.rs
+++ b/crates/core/src/commands/builder.rs
@@ -3,15 +3,29 @@
 
 use std::fmt;
 
+use itertools::Itertools;
+
 pub struct CommandStringBuilder {
     command: String,
 }
 
 impl CommandStringBuilder {
-    pub(crate) fn nix() -> Self {
-        Self {
+    pub(crate) fn nix(options: &[(String, String)]) -> Self {
+        let mut value = Self {
             command: "nix".to_string(),
-        }
+        };
+
+        value.args(
+            &options
+                .iter()
+                .map(|(name, value)| {
+                    let value = value.replace('\\', "\\\\").replace('"', "\\\"");
+                    format!("--option \"{name}\" \"{value}\"")
+                })
+                .collect_vec(),
+        );
+
+        value
     }
 
     pub(crate) fn new<S: AsRef<str>>(s: S) -> Self {
@@ -70,5 +84,27 @@ mod tests {
             std::convert::AsRef::<str>::as_ref(&builder)
         );
         assert_eq!(builder.to_string(), "a b c d e g");
+    }
+
+    #[test]
+    fn nix_options_with_spaces() {
+        let options = vec![
+            ("trusted-public-keys".to_string(), "key1 key2".to_string()),
+            (
+                "experimental-features".to_string(),
+                "nix-command flakes".to_string(),
+            ),
+        ];
+        let builder = CommandStringBuilder::nix(&options);
+        let output = builder.to_string();
+
+        assert!(
+            output.contains("\"trusted-public-keys\" \"key1 key2\""),
+            "expected quotes around value with spaces, got: {output}"
+        );
+        assert!(
+            output.contains("\"experimental-features\" \"nix-command flakes\""),
+            "expected quotes around value with spaces, got: {output}"
+        );
     }
 }

--- a/crates/core/src/commands/common.rs
+++ b/crates/core/src/commands/common.rs
@@ -2,6 +2,7 @@
 // Copyright 2024-2025 wire Contributors
 
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use tracing::instrument;
 
@@ -27,7 +28,7 @@ pub async fn push(
 ) -> Result<(), HiveLibError> {
     let target = target.0.read().await;
 
-    let mut command_string = CommandStringBuilder::nix();
+    let mut command_string = CommandStringBuilder::nix(&context.modifiers.options);
 
     command_string.args(&["--extra-experimental-features", "nix-command", "copy"]);
     command_string.opt_arg(substitute_on_destination, "--substitute-on-destination");
@@ -47,7 +48,7 @@ pub async fn push(
     let child = run_command_with_env(
         &CommandArguments::new(
             command_string,
-            context.modifiers,
+            context.modifiers.clone(),
             Some(context.name.clone()),
         )
         .mode(crate::commands::ChildOutputMode::Nix(Some(
@@ -55,7 +56,7 @@ pub async fn push(
         ))),
         HashMap::from([(
             "NIX_SSHOPTS".into(),
-            target.create_ssh_opts(context.modifiers)?,
+            target.create_ssh_opts(&context.modifiers)?,
         )]),
     )
     .await?;
@@ -99,7 +100,7 @@ fn get_common_command_help(error: &CommandError) -> Option<String> {
 
 pub async fn get_hive_node_names(
     location: &HiveLocation,
-    modifiers: SubCommandModifiers,
+    modifiers: Arc<SubCommandModifiers>,
 ) -> Result<Vec<String>, HiveLibError> {
     let output = evaluate_hive_attribute(location, &EvalGoal::Names, modifiers).await?;
     serde_json::from_str(&output).map_err(|err| {
@@ -113,7 +114,7 @@ pub async fn get_hive_node_names(
 pub async fn evaluate_hive_attribute(
     location: &HiveLocation,
     goal: &EvalGoal<'_>,
-    modifiers: SubCommandModifiers,
+    modifiers: Arc<SubCommandModifiers>,
 ) -> Result<String, HiveLibError> {
     let attribute = match location {
         HiveLocation::Flake {
@@ -143,7 +144,7 @@ pub async fn evaluate_hive_attribute(
         }
     };
 
-    let mut command_string = CommandStringBuilder::nix();
+    let mut command_string = CommandStringBuilder::nix(&modifiers.options);
     command_string.args(&[
         "--extra-experimental-features",
         "nix-command",

--- a/crates/core/src/commands/mod.rs
+++ b/crates/core/src/commands/mod.rs
@@ -47,7 +47,7 @@ pub enum Either<L, R> {
 
 #[derive(Debug)]
 pub(crate) struct CommandArguments<S: AsRef<str>> {
-    modifiers: SubCommandModifiers,
+    modifiers: Arc<SubCommandModifiers>,
     target: Option<SharedTarget>,
     output_mode: ChildOutputMode,
     command_string: S,
@@ -60,7 +60,7 @@ pub(crate) struct CommandArguments<S: AsRef<str>> {
 impl<S: AsRef<str>> CommandArguments<S> {
     pub(crate) fn new(
         command_string: S,
-        modifiers: SubCommandModifiers,
+        modifiers: Arc<SubCommandModifiers>,
         name: Option<Name>,
     ) -> Self {
         Self {

--- a/crates/core/src/commands/noninteractive.rs
+++ b/crates/core/src/commands/noninteractive.rs
@@ -37,7 +37,7 @@ pub async fn non_interactive_command_with_env<S: AsRef<str> + Sync>(
     envs: HashMap<String, String>,
 ) -> Result<NonInteractiveChildChip, HiveLibError> {
     let mut command = if let Some(ref target) = arguments.target {
-        create_sync_ssh_command(target, arguments.modifiers).await?
+        create_sync_ssh_command(target, &arguments.modifiers).await?
     } else {
         let mut command = Command::new("bash");
 
@@ -55,11 +55,11 @@ pub async fn non_interactive_command_with_env<S: AsRef<str> + Sync>(
         }
     );
 
-    let command_string = command_string.replace('\'', "'\''");
+    let command_string = command_string.replace('"', "\\\"");
 
     let command_string = arguments.privilege_escalation_command.as_ref().map_or_else(
-        || format!("bash -c '{command_string}'"),
-        |escalation_command| format!("{escalation_command} bash -c '{command_string}'"),
+        || format!("bash -c \"{command_string}\""),
+        |escalation_command| format!("{escalation_command} bash -c \"{command_string}\""),
     );
 
     debug!("{command_string}");
@@ -200,7 +200,7 @@ pub async fn handle_io<R>(
 #[allow(clippy::significant_drop_tightening)]
 async fn create_sync_ssh_command(
     target: &SharedTarget,
-    modifiers: SubCommandModifiers,
+    modifiers: &SubCommandModifiers,
 ) -> Result<Command, HiveLibError> {
     let target = target.0.read().await;
     let mut command = Command::new("ssh");

--- a/crates/core/src/commands/pty/mod.rs
+++ b/crates/core/src/commands/pty/mod.rs
@@ -303,7 +303,7 @@ async fn build_command<S: AsRef<str> + Sync>(
     command_string: &str,
 ) -> Result<CommandBuilder, HiveLibError> {
     let mut command = if let Some(ref target) = arguments.target {
-        let mut command = create_int_ssh_command(target, arguments.modifiers).await?;
+        let mut command = create_int_ssh_command(target, &arguments.modifiers).await?;
 
         // force ssh to use our pseudo terminal
         command.arg("-tt");
@@ -317,12 +317,12 @@ async fn build_command<S: AsRef<str> + Sync>(
         command
     };
 
-    let command_string = command_string.replace('\'', "'\''");
+    let command_string = command_string.replace('"', "\\\"");
 
     if let Some(ref escalation_command) = arguments.privilege_escalation_command {
-        command.arg(format!("{escalation_command} bash -c '{command_string}'"));
+        command.arg(format!("{escalation_command} bash -c \"{command_string}\""));
     } else {
-        command.arg(format!("bash -c '{command_string}'"));
+        command.arg(format!("bash -c \"{command_string}\""));
     }
 
     Ok(command)
@@ -426,7 +426,7 @@ impl Drop for StdinTermiosAttrGuard {
 #[allow(clippy::significant_drop_tightening)]
 async fn create_int_ssh_command(
     target: &SharedTarget,
-    modifiers: SubCommandModifiers,
+    modifiers: &SubCommandModifiers,
 ) -> Result<portable_pty::CommandBuilder, HiveLibError> {
     let target = target.0.read().await;
     let mut command = portable_pty::CommandBuilder::new("ssh");

--- a/crates/core/src/hive/executor.rs
+++ b/crates/core/src/hive/executor.rs
@@ -102,7 +102,7 @@ async fn evaluate_task(
     tx: tokio::sync::oneshot::Sender<Result<SafeStorePath<String>, HiveLibError>>,
     hive_location: Arc<HiveLocation>,
     name: Name,
-    modifiers: SubCommandModifiers,
+    modifiers: Arc<SubCommandModifiers>,
     on_new_evaluation: oneshot::Sender<SafeStorePath<String>>,
 ) {
     let output = evaluate_hive_attribute(&hive_location, &EvalGoal::GetTopLevel(&name), modifiers)
@@ -162,7 +162,7 @@ pub async fn execute(
                 tx,
                 plan.context.hive_location.clone(),
                 plan.context.name.clone(),
-                plan.context.modifiers,
+                plan.context.modifiers.clone(),
                 on_new_evaluation,
             )
             .in_current_span(),
@@ -260,7 +260,7 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.clone().into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit.clone(),
             None,
         );

--- a/crates/core/src/hive/mod.rs
+++ b/crates/core/src/hive/mod.rs
@@ -117,11 +117,15 @@ impl Hive {
     pub async fn new_from_path(
         location: &HiveLocation,
         cache: Arc<Option<InspectionCache>>,
-        modifiers: SubCommandModifiers,
+        modifiers: Arc<SubCommandModifiers>,
     ) -> Result<Self, HiveLibError> {
         info!("evaluating hive {location:?}");
 
-        if let Some(ref cache) = *cache
+        // Bypass cache when special nix options are present
+        let use_cache = modifiers.options.is_empty();
+
+        if use_cache
+            && let Some(ref cache) = *cache
             && let HiveLocation::Flake { prefetch, .. } = location
             && let Some(hive) = cache.get_hive(prefetch).await
         {
@@ -134,7 +138,8 @@ impl Hive {
             HiveLibError::HiveInitialisationError(HiveInitialisationError::ParseEvaluateError(err))
         })?;
 
-        if let Some(ref cache) = *cache
+        if use_cache
+            && let Some(ref cache) = *cache
             && let HiveLocation::Flake { prefetch, .. } = location
         {
             cache.store_hive(prefetch, &output).await;
@@ -279,9 +284,9 @@ impl HiveLocation {
     #[instrument(skip_all, name = "flake_prefetch", fields(uri = %uri))]
     async fn from_flake_uri(
         uri: String,
-        modifiers: SubCommandModifiers,
+        modifiers: Arc<SubCommandModifiers>,
     ) -> Result<Self, HiveLibError> {
-        let mut command_string = CommandStringBuilder::nix();
+        let mut command_string = CommandStringBuilder::nix(&modifiers.options);
         command_string.args(&[
             "flake",
             "prefetch",
@@ -318,7 +323,7 @@ impl HiveLocation {
 
 pub async fn get_hive_location(
     path: String,
-    modifiers: SubCommandModifiers,
+    modifiers: Arc<SubCommandModifiers>,
 ) -> Result<HiveLocation, HiveLibError> {
     let flakeref = FlakeRef::from_str(&path);
 
@@ -327,7 +332,8 @@ pub async fn get_hive_location(
             Some("hive.nix") => HiveLocation::HiveNix(path.clone()),
             Some(_) => {
                 if fs::metadata(path.join("flake.nix")).is_ok() {
-                    HiveLocation::from_flake_uri(path.display().to_string(), modifiers).await?
+                    HiveLocation::from_flake_uri(path.display().to_string(), modifiers.clone())
+                        .await?
                 } else {
                     HiveLocation::HiveNix(path.join("hive.nix"))
                 }
@@ -392,9 +398,13 @@ mod tests {
     async fn test_hive_file() {
         let location = location!(get_test_path!());
 
-        let hive = Hive::new_from_path(&location, None.into(), SubCommandModifiers::default())
-            .await
-            .unwrap();
+        let hive = Hive::new_from_path(
+            &location,
+            None.into(),
+            Arc::new(SubCommandModifiers::default()),
+        )
+        .await
+        .unwrap();
 
         let node = Node {
             target: node::Target::from_host("192.168.122.96"),
@@ -419,9 +429,13 @@ mod tests {
     async fn non_trivial_hive() {
         let location = location!(get_test_path!());
 
-        let hive = Hive::new_from_path(&location, None.into(), SubCommandModifiers::default())
-            .await
-            .unwrap();
+        let hive = Hive::new_from_path(
+            &location,
+            None.into(),
+            Arc::new(SubCommandModifiers::default()),
+        )
+        .await
+        .unwrap();
 
         let node = Node {
             target: node::Target::from_host("name"),
@@ -463,13 +477,17 @@ mod tests {
 
         let location = get_hive_location(
             tmp_dir.path().display().to_string(),
-            SubCommandModifiers::default(),
+            Arc::new(SubCommandModifiers::default()),
         )
         .await
         .unwrap();
-        let hive = Hive::new_from_path(&location, None.into(), SubCommandModifiers::default())
-            .await
-            .unwrap();
+        let hive = Hive::new_from_path(
+            &location,
+            None.into(),
+            Arc::new(SubCommandModifiers::default()),
+        )
+        .await
+        .unwrap();
 
         let mut nodes = HashMap::new();
 
@@ -495,7 +513,7 @@ mod tests {
         let location = location!(get_test_path!());
 
         assert_matches!(
-            Hive::new_from_path(&location, None.into(), SubCommandModifiers::default()).await,
+            Hive::new_from_path(&location, None.into(), Arc::new(SubCommandModifiers::default())).await,
             Err(HiveLibError::NixEvalError {
                 source: CommandError::CommandFailed {
                     logs,
@@ -513,7 +531,7 @@ mod tests {
         let location = location!(get_test_path!());
 
         assert_matches!(
-            Hive::new_from_path(&location, None.into(), SubCommandModifiers::default()).await,
+            Hive::new_from_path(&location, None.into(), Arc::new(SubCommandModifiers::default())).await,
             Err(HiveLibError::NixEvalError {
                 source: CommandError::CommandFailed {
                     logs,
@@ -532,9 +550,13 @@ mod tests {
         location.push("non_trivial_hive");
         let location = location!(location);
 
-        let mut hive = Hive::new_from_path(&location, None.into(), SubCommandModifiers::default())
-            .await
-            .unwrap();
+        let mut hive = Hive::new_from_path(
+            &location,
+            None.into(),
+            Arc::new(SubCommandModifiers::default()),
+        )
+        .await
+        .unwrap();
 
         assert_matches!(
             hive.force_always_local(vec!["non-existent".to_string()]),

--- a/crates/core/src/hive/node.rs
+++ b/crates/core/src/hive/node.rs
@@ -65,14 +65,14 @@ impl PartialEq for SharedTarget {
 
 impl Target {
     #[instrument(ret(level = tracing::Level::DEBUG), skip_all)]
-    pub fn create_ssh_opts(&self, modifiers: SubCommandModifiers) -> Result<String, HiveLibError> {
+    pub fn create_ssh_opts(&self, modifiers: &SubCommandModifiers) -> Result<String, HiveLibError> {
         self.create_ssh_args(modifiers, false).map(|x| x.join(" "))
     }
 
     #[instrument(ret(level = tracing::Level::DEBUG))]
     pub fn create_ssh_args(
         &self,
-        modifiers: SubCommandModifiers,
+        modifiers: &SubCommandModifiers,
         force_quiet: bool,
     ) -> Result<Vec<String>, HiveLibError> {
         let mut vector = vec![
@@ -106,7 +106,7 @@ impl Target {
     /// Tests the connection to a node
     pub async fn ping(
         &self,
-        modifiers: SubCommandModifiers,
+        modifiers: Arc<SubCommandModifiers>,
         should_quit: Arc<AtomicBool>,
         name: &Name,
     ) -> Result<(), HiveLibError> {
@@ -125,7 +125,7 @@ impl Target {
 
         let mut command_string = CommandStringBuilder::new("ssh");
         command_string.arg(format!("{}@{host}", self.user));
-        command_string.arg(self.create_ssh_opts(modifiers)?);
+        command_string.arg(self.create_ssh_opts(&modifiers)?);
         command_string.arg("exit");
 
         let output = run_command(
@@ -294,7 +294,7 @@ pub type BuildNameMap = Arc<Mutex<HashMap<u64, Arc<String>>>>;
 
 pub struct Context {
     pub hive_location: Arc<HiveLocation>,
-    pub modifiers: SubCommandModifiers,
+    pub modifiers: Arc<SubCommandModifiers>,
     pub state: StepState,
     pub should_quit: Arc<AtomicBool>,
     pub name: Name,
@@ -362,16 +362,20 @@ mod tests {
         ];
 
         assert_eq!(
-            target.create_ssh_args(subcommand_modifiers, false).unwrap(),
+            target
+                .create_ssh_args(&subcommand_modifiers, false)
+                .unwrap(),
             args
         );
         assert_eq!(
-            target.create_ssh_opts(subcommand_modifiers).unwrap(),
+            target.create_ssh_opts(&subcommand_modifiers).unwrap(),
             args.join(" ")
         );
 
         assert_eq!(
-            target.create_ssh_args(subcommand_modifiers, false).unwrap(),
+            target
+                .create_ssh_args(&subcommand_modifiers, false)
+                .unwrap(),
             [
                 "-l".to_string(),
                 target.user.to_string(),
@@ -385,7 +389,9 @@ mod tests {
         );
 
         assert_eq!(
-            target.create_ssh_args(subcommand_modifiers, false).unwrap(),
+            target
+                .create_ssh_args(&subcommand_modifiers, false)
+                .unwrap(),
             [
                 "-l".to_string(),
                 target.user.to_string(),
@@ -400,10 +406,12 @@ mod tests {
 
         // forced non interactive is the same as --non-interactive
         assert_eq!(
-            target.create_ssh_args(subcommand_modifiers, false).unwrap(),
+            target
+                .create_ssh_args(&subcommand_modifiers, false)
+                .unwrap(),
             target
                 .create_ssh_args(
-                    SubCommandModifiers {
+                    &SubCommandModifiers {
                         non_interactive: true,
                         ..Default::default()
                     },

--- a/crates/core/src/hive/plan.rs
+++ b/crates/core/src/hive/plan.rs
@@ -142,7 +142,7 @@ fn apply_plan(
     args: &ApplyGoalArgs,
     node: &Node,
     name: &Name,
-    modifiers: SubCommandModifiers,
+    modifiers: Arc<SubCommandModifiers>,
     hive_location: Arc<HiveLocation>,
     should_quit: Arc<AtomicBool>,
     cached_evaluation: Option<&SafeStorePath<String>>,
@@ -293,7 +293,7 @@ pub fn plan_for_node(
     name: Name,
     goal: &'_ Goal,
     hive_location: Arc<HiveLocation>,
-    modifiers: &SubCommandModifiers,
+    modifiers: &Arc<SubCommandModifiers>,
     should_quit: Arc<AtomicBool>,
     cached_evaluation: Option<&SafeStorePath<String>>,
 ) -> NodePlan {
@@ -334,7 +334,7 @@ pub fn plan_for_node(
             NodePlan {
                 context: Context {
                     state: StepState::default(),
-                    modifiers: *modifiers,
+                    modifiers: modifiers.clone(),
                     hive_location,
                     should_quit,
                     name,
@@ -348,7 +348,7 @@ pub fn plan_for_node(
             args,
             node,
             &name,
-            *modifiers,
+            modifiers.clone(),
             hive_location,
             should_quit,
             cached_evaluation,
@@ -412,7 +412,7 @@ mod tests {
             name.clone(),
             &Goal::Build,
             location.into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit,
             None,
         );
@@ -455,7 +455,7 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.clone().into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit.clone(),
             None,
         );
@@ -506,7 +506,7 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit,
             None,
         );
@@ -564,7 +564,7 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit,
             None,
         );
@@ -628,7 +628,7 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit,
             None,
         );
@@ -698,7 +698,7 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit,
             None,
         );
@@ -748,7 +748,7 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit,
             None,
         );
@@ -815,7 +815,7 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit,
             None,
         );
@@ -877,7 +877,7 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit,
             None,
         );
@@ -920,7 +920,7 @@ mod tests {
             name.clone(),
             &Goal::Build,
             location.into(),
-            &SubCommandModifiers::default(),
+            &Arc::new(SubCommandModifiers::default()),
             should_quit,
             Some(&cached),
         );
@@ -953,10 +953,10 @@ mod tests {
             name.clone(),
             &Goal::Build,
             location.into(),
-            &SubCommandModifiers {
+            &Arc::new(SubCommandModifiers {
                 experimental_nix_client: true,
                 ..Default::default()
-            },
+            }),
             should_quit,
             None,
         );
@@ -1006,10 +1006,10 @@ mod tests {
                 handle_unreachable: HandleUnreachable::default(),
             }),
             location.into(),
-            &SubCommandModifiers {
+            &Arc::new(SubCommandModifiers {
                 experimental_nix_client: true,
                 ..Default::default()
-            },
+            }),
             should_quit,
             None,
         );

--- a/crates/core/src/hive/steps/activate.rs
+++ b/crates/core/src/hive/steps/activate.rs
@@ -46,7 +46,7 @@ async fn wait_for_ping(target: &SharedTarget, ctx: &Context) -> Result<(), HiveL
         warn!("Trying to ping {host} (attempt {}/{MAX_ATTEMPTS})", num + 1);
 
         let result = target
-            .ping(ctx.modifiers, ctx.should_quit.clone(), &ctx.name)
+            .ping(ctx.modifiers.clone(), ctx.should_quit.clone(), &ctx.name)
             .await;
 
         if result.is_ok() {
@@ -79,12 +79,16 @@ impl SwitchToConfiguration {
         command_string.arg(built_path.to_absolute_path());
 
         let child = run_command(
-            &CommandArguments::new(command_string, ctx.modifiers, Some(ctx.name.clone()))
-                .mode(crate::commands::ChildOutputMode::Nix(Some(
-                    ctx.name.clone(),
-                )))
-                .execute_on_remote(self.target.clone())
-                .privileged(&self.privilege_escalation_command),
+            &CommandArguments::new(
+                command_string,
+                ctx.modifiers.clone(),
+                Some(ctx.name.clone()),
+            )
+            .mode(crate::commands::ChildOutputMode::Nix(Some(
+                ctx.name.clone(),
+            )))
+            .execute_on_remote(self.target.clone())
+            .privileged(&self.privilege_escalation_command),
         )
         .await?;
 
@@ -128,10 +132,14 @@ impl ExecuteStep for SwitchToConfiguration {
         });
 
         let child = run_command(
-            &CommandArguments::new(command_string, ctx.modifiers, Some(ctx.name.clone()))
-                .execute_on_remote(self.target.clone())
-                .privileged(&self.privilege_escalation_command)
-                .log_stdout(),
+            &CommandArguments::new(
+                command_string,
+                ctx.modifiers.clone(),
+                Some(ctx.name.clone()),
+            )
+            .execute_on_remote(self.target.clone())
+            .privileged(&self.privilege_escalation_command)
+            .log_stdout(),
         )
         .await?;
 
@@ -152,10 +160,14 @@ impl ExecuteStep for SwitchToConfiguration {
                 warn!("Rebooting {name}!", name = ctx.name);
 
                 let reboot = run_command(
-                    &CommandArguments::new("reboot now", ctx.modifiers, Some(ctx.name.clone()))
-                        .log_stdout()
-                        .execute_on_remote(Some(target.clone()))
-                        .privileged(&self.privilege_escalation_command),
+                    &CommandArguments::new(
+                        "reboot now",
+                        ctx.modifiers.clone(),
+                        Some(ctx.name.clone()),
+                    )
+                    .log_stdout()
+                    .execute_on_remote(Some(target.clone()))
+                    .privileged(&self.privilege_escalation_command),
                 )
                 .await?;
 

--- a/crates/core/src/hive/steps/build.rs
+++ b/crates/core/src/hive/steps/build.rs
@@ -73,7 +73,7 @@ impl ExecuteStep for Build {
                     Either::Left(
                         open_remote_client(
                             &target,
-                            ctx.modifiers,
+                            ctx.modifiers.clone(),
                             |log, map, print| {
                                 trace_nix_log_message(log, map, print, Some(ctx.name.clone()))
                             },
@@ -178,7 +178,7 @@ impl ExecuteStep for Build {
                 };
 
                 // use regular nix build command
-                let mut command_string = CommandStringBuilder::nix();
+                let mut command_string = CommandStringBuilder::nix(&ctx.modifiers.options);
                 command_string.args(&[
                     "--extra-experimental-features",
                     "nix-command",
@@ -191,18 +191,20 @@ impl ExecuteStep for Build {
                 command_string.arg(&attribute);
 
                 let status = run_command_with_env(
-                    &CommandArguments::new(command_string, ctx.modifiers, Some(ctx.name.clone()))
-                        // build remotely if asked for AND we isnt applying locally
-                        .execute_on_remote(match metadata {
-                            NixCommandBuildMetadata::Remotely { target, .. } => {
-                                Some(target.clone())
-                            }
-                            NixCommandBuildMetadata::Locally { .. } => None,
-                        })
-                        .mode(crate::commands::ChildOutputMode::Nix(Some(
-                            ctx.name.clone(),
-                        )))
-                        .log_stdout(),
+                    &CommandArguments::new(
+                        command_string,
+                        ctx.modifiers.clone(),
+                        Some(ctx.name.clone()),
+                    )
+                    // build remotely if asked for AND we isnt applying locally
+                    .execute_on_remote(match metadata {
+                        NixCommandBuildMetadata::Remotely { target, .. } => Some(target.clone()),
+                        NixCommandBuildMetadata::Locally { .. } => None,
+                    })
+                    .mode(crate::commands::ChildOutputMode::Nix(Some(
+                        ctx.name.clone(),
+                    )))
+                    .log_stdout(),
                     std::collections::HashMap::new(),
                 )
                 .await?

--- a/crates/core/src/hive/steps/keys.rs
+++ b/crates/core/src/hive/steps/keys.rs
@@ -253,11 +253,15 @@ impl ExecuteStep for Keys {
         ));
 
         let mut child = run_command(
-            &CommandArguments::new(command_string, ctx.modifiers, Some(ctx.name.clone()))
-                .execute_on_remote(self.target.clone())
-                .privileged(&self.privilege_escalation_command)
-                .keep_stdin_open()
-                .log_stdout(),
+            &CommandArguments::new(
+                command_string,
+                ctx.modifiers.clone(),
+                Some(ctx.name.clone()),
+            )
+            .execute_on_remote(self.target.clone())
+            .privileged(&self.privilege_escalation_command)
+            .keep_stdin_open()
+            .log_stdout(),
         )
         .await?;
 

--- a/crates/core/src/hive/steps/ping.rs
+++ b/crates/core/src/hive/steps/ping.rs
@@ -35,7 +35,7 @@ impl ExecuteStep for Ping {
             );
 
             if target
-                .ping(ctx.modifiers, ctx.should_quit.clone(), &ctx.name)
+                .ping(ctx.modifiers.clone(), ctx.should_quit.clone(), &ctx.name)
                 .await
                 .is_ok()
             {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -54,7 +54,7 @@ pub enum StrictHostKeyChecking {
     AcceptNew,
 }
 
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 #[allow(clippy::struct_excessive_bools)]
 pub struct SubCommandModifiers {
     pub show_trace: bool = false,
@@ -63,6 +63,7 @@ pub struct SubCommandModifiers {
     pub ssh_verbosity: usize = 0,
     pub print_build_logs: bool = false,
     pub experimental_nix_client: bool = false,
+    pub options: Arc<Vec<(String, String)>>
 }
 
 impl Default for SubCommandModifiers {
@@ -70,6 +71,7 @@ impl Default for SubCommandModifiers {
         Self {
             non_interactive: !std::io::stdin().is_terminal(),
             ssh_accept_host: StrictHostKeyChecking::default(),
+            options: Arc::new(Vec::new()),
             ..
         }
     }
@@ -117,7 +119,7 @@ pub async fn acquire_stdin_lock<'a>() -> Result<ClobberGuard<'a>, AcquireError> 
 #[instrument(skip(trace_callback))]
 pub async fn open_remote_client<D, T>(
     target: &D,
-    modifiers: SubCommandModifiers,
+    modifiers: Arc<SubCommandModifiers>,
     trace_callback: T,
     should_quit: Arc<AtomicBool>,
 ) -> Result<(NixClient<ChildStdout, ChildStdin, T>, String), HiveLibError>
@@ -126,7 +128,7 @@ where
     T: Fn(LogMessage, &Arc<Mutex<HashMap<u64, Arc<String>>>>, bool) -> Option<String> + Send,
 {
     let mut command = Command::new("ssh")
-        .args(target.create_ssh_args(modifiers, true)?)
+        .args(target.create_ssh_args(&modifiers, true)?)
         .arg(target.get_preferred_host()?.to_string())
         .arg("nix-daemon --stdio")
         .stdin(Stdio::piped())
@@ -178,7 +180,7 @@ pub async fn push_with_daemon(
 
     let (mut remote_daemon, host) = open_remote_client(
         &target,
-        context.modifiers,
+        context.modifiers.clone(),
         |log, map, print| trace_nix_log_message(log, map, print, Some(context.name.clone())),
         context.should_quit.clone(),
     )

--- a/crates/core/src/test_macros.rs
+++ b/crates/core/src/test_macros.rs
@@ -35,7 +35,7 @@ macro_rules! location {
     ($path:expr) => {{
         $crate::hive::get_hive_location(
             $path.display().to_string(),
-            $crate::SubCommandModifiers::default(),
+            std::sync::Arc::new($crate::SubCommandModifiers::default()),
         )
         .await
         .unwrap()


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `--option NAME VALUE` flag for Apply and Build commands.
  * Supplied options are now included when generating Nix commands and prefetch operations.
* **Bug Fixes**
  * Preserved command-line modifiers during target resolution and execution.
  * Improved option handling across local, remote, interactive, and non-interactive workflows.
  * Ensured configured options remain available throughout planning and execution.
  * Prevented cached inspection results from overriding custom Nix options.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->